### PR TITLE
replace quick guide with link to qib

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links
 main:
-  - title: "Quick-Start Guide"
-    url: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
+  - title: "Quadram Institute"
+    url: https://ww.quadram.ac.uk
   # - title: "About"
   #   url: https://mmistakes.github.io/minimal-mistakes/about/
   # - title: "Sample Posts"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links
 main:
   - title: "Quadram Institute"
-    url: https://ww.quadram.ac.uk
+    url: https://www.quadram.ac.uk
   # - title: "About"
   #   url: https://mmistakes.github.io/minimal-mistakes/about/
   # - title: "Sample Posts"


### PR DESCRIPTION
Removed static link to theme docs and replaced with link to the institute. the changed file is the place to organise the top bar, also with internal links